### PR TITLE
Fix code generation for clang

### DIFF
--- a/generator/include/embedder.hpp
+++ b/generator/include/embedder.hpp
@@ -5,13 +5,13 @@ R"embedder(
 
     #define RESOURCE(name, path)                        \
     __asm__ (                                           \
-        ".global _" #name "\n"                          \
-        ".global _" #name "_size\n"                     \
-        "_" #name ":\n"                                 \
+        ".global " #name "\n"                          \
+        ".global " #name "_size\n"                     \
+        #name ":\n"                                 \
             ".incbin \"" path "\"\n"                    \
             ".align 8\n"                                \
-        "_" #name "_size:\n"                            \
-            ".int _" #name "_size - _" #name " - 1\n"   \
+        #name "_size:\n"                            \
+            ".int " #name "_size - " #name " - 1\n"   \
             ".align 8\n"                                \
     )
 


### PR DESCRIPTION
Code generation with clang set resource names to `_<name>` unlike for GCC where it is `<name>`, while exporting the symbol `<name>` thus resulting in this kind of linking error (sample from ImHex build):

```
[ 92%] Linking CXX executable imhex
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource2'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource3_size'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource1_size'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource4'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource0_size'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource2_size'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource0'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource4_size'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource3'
/usr/bin/ld: plugins/libimhex/libimhex.so: undefined reference to `resource1'
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
```

This patch fixes that by simply removing the prefixed `_` character