### PR TITLE
add new variable to define compiler/flags for generator project when crosscompiling

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -1,6 +1,15 @@
 project(generator-${LIBROMFS_PROJECT_NAME})
 set(CMAKE_CXX_STANDARD 20)
 
+# This is a code generator, so when cross compiling it should be built with the host (native) toolchain
+if(CMAKE_CROSSCOMPILING)
+    SET(CMAKE_C_COMPILER ${NATIVE_CMAKE_C_COMPILER})
+    SET(CMAKE_CXX_COMPILER ${NATIVE_CMAKE_CXX_COMPILER})
+    SET(CMAKE_C_FLAGS ${NATIVE_CMAKE_C_FLAGS})
+    SET(CMAKE_CXX_FLAGS ${NATIVE_CMAKE_CXX_FLAGS})
+endif()
+
+
 # Add sources
 add_executable(${PROJECT_NAME}
     source/main.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,7 +18,7 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC LIBROMFS_PROJECT_NAME=${LIBROM
 
 # Make sure libromfs gets rebuilt when any of the resources are changed
 add_custom_command(OUTPUT ${ROMFS}
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:generator-${LIBROMFS_PROJECT_NAME}>
+        COMMAND $<TARGET_FILE:generator-${LIBROMFS_PROJECT_NAME}>
         DEPENDS ../generator ${ROMFS_FILES}
         )
 


### PR DESCRIPTION
This is a hack, as officially CMake would want us to make two CMake builds. But this also works and is easier to do