### PR TITLE
gen/lib: support #embed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 option(LIBROMFS_PROJECT_NAME "Project name" "")
 option(LIBROMFS_RESOURCE_LOCATION "Resource location" "")
 option(LIBROMFS_COMPRESS_RESOURCES "If resources should be zlib compressed" ON)
+option(LIBROMFS_USE_EMBED "If #embed should be used for resource inclusion" ON)
 
 if (NOT LIBROMFS_PROJECT_NAME)
     message(FATAL_ERROR "LIBROMFS_PROJECT_NAME is not set")

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -1,5 +1,4 @@
 project(generator-${LIBROMFS_PROJECT_NAME})
-set(CMAKE_CXX_STANDARD 20)
 
 # This is a code generator, so when cross compiling it should be built with the host (native) toolchain
 if (CMAKE_CROSSCOMPILING)
@@ -21,6 +20,7 @@ string(REPLACE ";" "," LIBROMFS_RESOURCE_LOCATION_STRING "${LIBROMFS_RESOURCE_LO
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE RESOURCE_LOCATION="${LIBROMFS_RESOURCE_LOCATION_STRING}" LIBROMFS_PROJECT_NAME="${LIBROMFS_PROJECT_NAME}")
 target_include_directories(${PROJECT_NAME} PRIVATE include)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 
 if (LIBROMFS_COMPRESS_RESOURCES)
     find_package(ZLIB QUIET)
@@ -40,6 +40,15 @@ if (LIBROMFS_COMPRESS_RESOURCES)
     else()
         message(WARNING "Requested RomFS to be compressed but zlib is unavailable! Resulting RomFS will NOT be compressed.")
     endif()
+endif()
+
+if (LIBROMFS_USE_EMBED)
+    set(LIBROMFS_COMPRESSED_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/compressed/${LIBROMFS_PROJECT_NAME}")
+    file(MAKE_DIRECTORY ${LIBROMFS_COMPRESSED_OUTPUT_DIR})
+    target_compile_definitions(${PROJECT_NAME} PRIVATE
+        LIBROMFS_USE_EMBED
+        COMPRESSED_OUTPUT_DIR="${LIBROMFS_COMPRESSED_OUTPUT_DIR}"
+    )
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")

--- a/generator/source/main.cpp
+++ b/generator/source/main.cpp
@@ -84,51 +84,57 @@ int main() {
             auto path = fs::canonical(fs::absolute(entry.path()));
             auto relativePath = fs::relative(entry.path(), fs::absolute(resourceLocation));
 
-            std::vector<std::uint8_t> inputData;
-            inputData.resize(entry.file_size());
+            // Skip file processing only if we don't have to compress resources and we're using #embed
+            #if defined(LIBROMFS_COMPRESS_RESOURCES) || (!defined(LIBROMFS_USE_EMBED) || !defined(__has_embed))
+                std::vector<std::uint8_t> inputData;
+                inputData.resize(entry.file_size());
 
-            auto file = std::fopen(entry.path().string().c_str(), "rb");
-            inputData.resize(std::fread(inputData.data(), 1, entry.file_size(), file));
-            std::fclose(file);
+                auto file = std::fopen(entry.path().string().c_str(), "rb");
+                inputData.resize(std::fread(inputData.data(), 1, entry.file_size(), file));
+                std::fclose(file);
 
-            inputData.push_back(0x00);
+                inputData.push_back(0x00);
 
-            std::vector<std::uint8_t> bytes;
-            #if defined(LIBROMFS_COMPRESS_RESOURCES)
-                z_stream stream;
-                stream.zalloc = Z_NULL;
-                stream.zfree = Z_NULL;
-                stream.opaque = Z_NULL;
-                stream.avail_in = inputData.size();
-                stream.next_in = inputData.data();
+                std::vector<std::uint8_t> bytes;
+                #if defined(LIBROMFS_COMPRESS_RESOURCES)
+                    z_stream stream;
+                    stream.zalloc = Z_NULL;
+                    stream.zfree = Z_NULL;
+                    stream.opaque = Z_NULL;
+                    stream.avail_in = inputData.size();
+                    stream.next_in = inputData.data();
 
-                // Initialize the zlib deflate operation
-                if (deflateInit(&stream, Z_BEST_COMPRESSION) != Z_OK) {
-                    continue;
-                }
+                    // Initialize the zlib deflate operation
+                    if (deflateInit(&stream, Z_BEST_COMPRESSION) != Z_OK) {
+                        continue;
+                    }
 
-                // Estimate the compressed size and allocate the buffer
-                bytes.resize(inputData.size() * 1.1 + 12); // Slightly larger than the input size
+                    // Estimate the compressed size and allocate the buffer
+                    bytes.resize(inputData.size() * 1.1 + 12); // Slightly larger than the input size
 
-                stream.avail_out = bytes.size();
-                stream.next_out  = bytes.data();
+                    stream.avail_out = bytes.size();
+                    stream.next_out  = bytes.data();
 
-                // Perform the compression
-                if (deflate(&stream, Z_FINISH) != Z_STREAM_END) {
+                    // Perform the compression
+                    if (deflate(&stream, Z_FINISH) != Z_STREAM_END) {
+                        deflateEnd(&stream);
+                        continue;
+                    }
+
+                    // Resize the output buffer to the actual size
+                    bytes.resize(stream.total_out);
+
+                    // Clean up
                     deflateEnd(&stream);
-                    continue;
-                }
-
-                // Resize the output buffer to the actual size
-                bytes.resize(stream.total_out);
-
-                // Clean up
-                deflateEnd(&stream);
+                #else
+                    bytes = std::move(inputData);
+                #endif
+                size_t outputArraySize = bytes.size() + 1;
             #else
-                bytes = std::move(inputData);
+                size_t outputArraySize = entry.file_size();
             #endif
 
-            outputFile << "static std::array<std::uint8_t, " << bytes.size() + 1 << "> " << "resource_" LIBROMFS_PROJECT_NAME "_" << identifierCount << " = {\n";
+            outputFile << "static std::array<std::uint8_t, " << outputArraySize << "> " << "resource_" LIBROMFS_PROJECT_NAME "_" << identifierCount << " = {\n";
             outputFile << "    ";
 
             #if defined(LIBROMFS_USE_EMBED) && defined(__has_embed)

--- a/generator/source/main.cpp
+++ b/generator/source/main.cpp
@@ -131,11 +131,22 @@ int main() {
             outputFile << "static std::array<std::uint8_t, " << bytes.size() + 1 << "> " << "resource_" LIBROMFS_PROJECT_NAME "_" << identifierCount << " = {\n";
             outputFile << "    ";
 
-            for (auto byte : bytes) {
-                outputFile << static_cast<std::uint32_t>(byte) << ",";
-            }
+            #if defined(LIBROMFS_USE_EMBED) && defined(__has_embed)
+                #ifdef LIBROMFS_COMPRESS_RESOURCES
+                {
+                    path = fs::path(COMPRESSED_OUTPUT_DIR) / std::to_string(identifierCount);
+                    std::ofstream compressedFile(path);
+                    compressedFile.write(std::bit_cast<const char*>(bytes.data()), bytes.size());
+                }
+                #endif
+                outputFile << "#embed " << path;
+            #else
+                for (auto byte : bytes) {
+                    outputFile << static_cast<std::uint32_t>(byte) << ",";
+                }
+            #endif
 
-            outputFile << " };\n\n";
+            outputFile << "\n};\n\n";
 
             paths.push_back(relativePath);
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,5 @@
 project("libromfs-${LIBROMFS_PROJECT_NAME}")
 
-set(CMAKE_CXX_STANDARD 20)
-
 # Gather romfs files
 set(ROMFS_FILES "")
 
@@ -20,6 +18,12 @@ add_library(${PROJECT_NAME} STATIC
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 target_compile_definitions(${PROJECT_NAME} PUBLIC LIBROMFS_PROJECT_NAME=${LIBROMFS_PROJECT_NAME})
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+
+if (LIBROMFS_USE_EMBED AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Silence #embed warning on Clang
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wno-c23-extensions)
+endif()
 
 if (LIBROMFS_COMPRESS_RESOURCES)
     find_package(ZLIB QUIET)


### PR DESCRIPTION
We specify the C++ version using target_compile_features instead of CMAKE_CXX_STANDARD since that automatically upgrades the C++ version if the consuming project sets a higher CMAKE_CXX_STANDARD. It's not strictly necessary, given that both Clang and GCC support #embed in C++20 mode, but it's good for correctness.

Closes #10